### PR TITLE
Refactor concurrency to reduce contention and lose global variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,12 +443,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -888,8 +920,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flexi_logger 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -987,6 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
@@ -999,7 +1032,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 name = "v9_worker"
 version = "0.1.0"
 authors = ["Gregor Peach <gregorpeach@gmail.com>"]
+description = "The worker node application code for the velocity-9 serverless platform"
 edition = "2018"
 
 [dependencies]
 failure = { version = "0.1.5", features = ["derive"]}
 flexi_logger = "0.14.3"
 hyper = "0.12.35"
-lazy_static = "1.4.0"
 log = "0.4.8"
+parking_lot = "0.9.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-max_width=115
+max_width=105

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,31 +5,27 @@ use hyper::{Body, Response};
 
 #[derive(Debug, Fail)]
 pub enum WorkerError {
-    HyperError(hyper::error::Error),
-    InvalidUtf8Error(Utf8Error),
-    MutexPoisonedError,
+    Hyper(hyper::error::Error),
+    InternalJsonHandling(serde_json::Error),
+    InvalidUtf8(Utf8Error),
     PathNotFound(String),
-    JsonHandlingError(serde_json::Error),
+    WrongMethod,
 }
 
 impl Display for WorkerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         // Technically this isn't very DRY, but I felt like factoring it out hurt readability YMMV
         match self {
-            WorkerError::HyperError(e) => {
+            WorkerError::Hyper(e) => {
                 f.write_str("WorkerError, caused by internal hyper error (")?;
                 e.fmt(f)?;
                 f.write_str(")")?;
             }
 
-            WorkerError::InvalidUtf8Error(e) => {
+            WorkerError::InvalidUtf8(e) => {
                 f.write_str("WorkerError, caused by internal utf8 decode error (")?;
                 e.fmt(f)?;
                 f.write_str(")")?;
-            }
-
-            WorkerError::MutexPoisonedError => {
-                f.write_str("WorkerError, caused by internal mutex poisoning")?;
             }
 
             WorkerError::PathNotFound(path) => {
@@ -38,10 +34,14 @@ impl Display for WorkerError {
                 f.write_str(")")?;
             }
 
-            WorkerError::JsonHandlingError(e) => {
+            WorkerError::InternalJsonHandling(e) => {
                 f.write_str("WorkerError, caused by internal serde_json error (")?;
                 e.fmt(f)?;
                 f.write_str(")")?;
+            }
+
+            WorkerError::WrongMethod => {
+                f.write_str("WorkerError, invalid http verb")?;
             }
         }
         Ok(())
@@ -52,27 +52,36 @@ impl Into<Response<Body>> for WorkerError {
     fn into(self) -> Response<Body> {
         match self {
             // Special case the "PathNotFound" error, since it maps cleanly to a 404
-            WorkerError::PathNotFound(_) => Response::builder().status(404).body(Body::from("")).unwrap(),
+            WorkerError::PathNotFound(_) => {
+                Response::builder().status(404).body(Body::from("")).unwrap()
+            }
+
+            // Also special case the "WrongMethodError" error since it maps cleanly to a 405
+            WorkerError::WrongMethod => Response::builder().status(405).body(Body::from("")).unwrap(),
+
             // Otherwise a 500 response is fine
-            e => Response::builder().status(500).body(Body::from(e.to_string())).unwrap(),
+            e => Response::builder()
+                .status(500)
+                .body(Body::from(e.to_string()))
+                .unwrap(),
         }
     }
 }
 
 impl From<hyper::error::Error> for WorkerError {
     fn from(e: hyper::error::Error) -> Self {
-        WorkerError::HyperError(e)
+        WorkerError::Hyper(e)
     }
 }
 
 impl From<Utf8Error> for WorkerError {
     fn from(e: Utf8Error) -> Self {
-        WorkerError::InvalidUtf8Error(e)
+        WorkerError::InvalidUtf8(e)
     }
 }
 
 impl From<serde_json::Error> for WorkerError {
     fn from(e: serde_json::Error) -> Self {
-        WorkerError::JsonHandlingError(e)
+        WorkerError::InternalJsonHandling(e)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -35,6 +35,8 @@ pub enum ActivationStatus {
     FailedToFindExecutable,
     #[serde(rename = "failed-to-start")]
     FailedToStart,
+    #[serde(rename = "invalid-request")]
+    InvalidRequest,
 }
 
 #[derive(Clone, Deserialize, Debug, Eq, Hash, PartialEq, Serialize)]
@@ -58,6 +60,8 @@ pub enum DeactivationStatus {
     DeactivationSuccessful,
     #[serde(rename = "failed-to-deactivate")]
     FailedToDeactivate,
+    #[serde(rename = "invalid-request")]
+    InvalidRequest,
 }
 
 #[derive(Clone, Deserialize, Debug, Eq, Hash, PartialEq, Serialize)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use hyper::rt::{self, Future};
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server};
@@ -5,9 +7,11 @@ use hyper::{Body, Request, Response, Server};
 const PRODUCTION_PORT: u16 = 80;
 const DEVELOPMENT_PORT: u16 = 8082;
 
-pub type BoxedHyperFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::error::Error> + Send>;
-
-pub fn start_server(development_mode: bool, handler: fn(Request<Body>) -> BoxedHyperFuture) {
+pub fn start_server<S, F>(development_mode: bool, state: Arc<S>, handler: fn(Arc<S>, Request<Body>) -> F)
+where
+    S: Send + Sync + 'static,
+    F: Future<Item = Response<Body>, Error = hyper::error::Error> + Send + 'static,
+{
     let port = if development_mode {
         DEVELOPMENT_PORT
     } else {
@@ -17,7 +21,10 @@ pub fn start_server(development_mode: bool, handler: fn(Request<Body>) -> BoxedH
     let addr = ([127, 0, 0, 1], port).into();
     debug!("Spinning up server on {:?}", addr);
 
-    let new_service = move || service_fn(handler);
+    let new_service = move || {
+        let copied_state = state.clone();
+        service_fn(move |req| handler(copied_state.clone(), req))
+    };
 
     let server = Server::bind(&addr)
         .serve(new_service)


### PR DESCRIPTION
- Get rid of our global request handler, and instead pass in state
- Generally clean up our concurrency stuff to reduce contention on the happy path
- Switch to using parking_lot of stdlib rwlocks/mutexes (their primitives are fair, which we care about)
- Actually return invalid request errors according to the spec
- Rename the error variants so they aren't redundant
- Actually validate http verbs