### PR TITLE
Enable clippy::cast_possible_truncation, then fix warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 use std::io;
+use std::num::TryFromIntError;
 use std::str::Utf8Error;
 
 use failure::Backtrace;
@@ -25,6 +26,7 @@ impl WorkerError {
 pub enum WorkerErrorKind {
     Hyper(hyper::error::Error),
     Io(io::Error),
+    IntegerConversion(TryFromIntError),
     InternalJsonHandling(serde_json::Error),
     InvalidUtf8(Utf8Error),
     Nix(nix::Error),
@@ -47,6 +49,12 @@ impl Display for WorkerError {
 
             WorkerErrorKind::Io(e) => {
                 f.write_str("WorkerError, caused by internal I/O error (")?;
+                e.fmt(f)?;
+                f.write_str(")")?;
+            }
+
+            WorkerErrorKind::IntegerConversion(e) => {
+                f.write_str("WorkerError, caused by internal integer conversion error (")?;
                 e.fmt(f)?;
                 f.write_str(")")?;
             }
@@ -134,6 +142,12 @@ impl From<hyper::error::Error> for WorkerError {
 impl From<io::Error> for WorkerError {
     fn from(e: io::Error) -> Self {
         WorkerErrorKind::Io(e).into()
+    }
+}
+
+impl From<TryFromIntError> for WorkerError {
+    fn from(e: TryFromIntError) -> Self {
+        WorkerErrorKind::IntegerConversion(e).into()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,7 @@
 // I'd like the most pedantic warning level
 #![warn(clippy::pedantic, clippy::needless_borrow)]
-// But I don't care about these ones for now (most applicable since the code isn't fleshed out)
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::cast_possible_truncation,
-    clippy::cast_precision_loss
-)]
+// But I don't care about these ones
+#![allow(clippy::cast_precision_loss, clippy::module_name_repetitions)]
 
 #[macro_use]
 extern crate failure;

--- a/src/named_pipe.rs
+++ b/src/named_pipe.rs
@@ -1,6 +1,6 @@
+use std::convert::TryInto;
 use std::fs::File;
 use std::fs::OpenOptions;
-use std::os::raw::c_int;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::io::RawFd;
@@ -139,7 +139,7 @@ impl NamedPipe {
             let poll_flags = PollFlags::POLLOUT;
             poll(
                 &mut [PollFd::new(c_in_fd, poll_flags)],
-                (deadline - Instant::now()).as_millis() as c_int,
+                (deadline - Instant::now()).as_millis().try_into()?,
             )?;
 
             // Then write the bytes
@@ -173,7 +173,7 @@ impl NamedPipe {
             let poll_flags = PollFlags::POLLIN;
             poll(
                 &mut [PollFd::new(c_out_fd, poll_flags)],
-                (deadline - Instant::now()).as_millis() as c_int,
+                (deadline - Instant::now()).as_millis().try_into()?,
             )?;
 
             // If we've timed out, then just return an error


### PR DESCRIPTION
This makes the integer conversions we do more robust