### PR TITLE
Add 404 message for router

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -159,9 +159,11 @@ impl Into<Response<Body>> for WorkerError {
     fn into(self) -> Response<Body> {
         match &self.kind {
             // Special case the "PathNotFound" error, since it maps cleanly to a 404
+            // IMPORTANT: The 404 message here is part of our API
+            // DO NOT CHANGE without modifying the router
             WorkerErrorKind::PathNotFound(_) => Response::builder()
                 .status(StatusCode::NOT_FOUND)
-                .body(Body::from(""))
+                .body(Body::from("v9: worker 404"))
                 .unwrap(),
 
             // Also special case the "WrongMethodError" error since it maps cleanly to a 405


### PR DESCRIPTION
This will let us differentiate between a 404 from the worker vs a 404 from a component

Open question whether this should instead be a custom error code. @pcodes thoughts?